### PR TITLE
Fix rustdoc.css CSS tab-size property

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1082,8 +1082,8 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 
 pre.rust {
 	position: relative;
-	tab-width: 4;
-	-moz-tab-width: 4;
+	tab-size: 4;
+	-moz-tab-size: 4;
 }
 
 .search-failed {


### PR DESCRIPTION
This fixes the CSS tab size property names which are called `tab-size` / `-moz-tab-size` and not `tab-width`

Old issue https://github.com/rust-lang/rust/issues/49155 and related PR https://github.com/rust-lang/rust/pull/50947

tab-size: https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size

